### PR TITLE
chore: add initial classroom app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+dist
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # HappyClass
+
+Classroom interaction web app skeleton built with Node.js (Express + Socket.IO) and Vite + React + MUI.
+
+## Development
+
+Install dependencies and run both server and web apps:
+
+```bash
+npm install
+npm run dev
+```
+
+Server runs on http://localhost:5174 and web client on http://localhost:5173.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "class-interact",
+  "private": true,
+  "workspaces": ["server", "web"],
+  "scripts": {
+    "dev": "npm -w server run dev & npm -w web run dev",
+    "build": "npm -w server run build && npm -w web run build",
+    "start": "npm -w server start"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "server",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsup src/index.ts --format esm --dts --out-dir dist",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "socket.io": "^4.7.5",
+    "socket.io-redis": "^6.1.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.1",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import http from 'http';
+import cors from 'cors';
+import { Server } from 'socket.io';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// in-memory stores (v1 简化)
+const rooms = new Map<string, { code: string; students: Set<string>; currentQ?: any }>();
+const questions = new Map<string, any>();
+const aggregates = new Map<string, any>();
+
+// REST 示例：创建房间
+app.post('/api/rooms', (_req, res) => {
+  const code = Math.random().toString(36).substring(2, 8).toUpperCase();
+  rooms.set(code, { code, students: new Set() });
+  res.json({ code });
+});
+
+// REST 示例：发布题目（写入并通过 WS 推送）
+app.post('/api/questions/:id/publish', (req, res) => {
+  const q = questions.get(req.params.id);
+  if (!q) return res.status(404).end();
+  io.to(`room:${q.code}`).emit('question:published', q);
+  rooms.get(q.code)!.currentQ = q;
+  aggregates.set(q.id, { total: 0, counts: Array(q.options?.length || 0).fill(0), tf: { true: 0, false: 0 }, text: new Map<string, number>() });
+  res.json({ ok: true });
+});
+
+const server = http.createServer(app);
+const io = new Server(server, { cors: { origin: '*' } });
+
+io.of('/room').on('connection', (socket) => {
+  socket.on('student:join', ({ code, nickname, anonymous }, ack) => {
+    socket.join(`room:${code}`);
+    rooms.get(code)?.students.add(socket.id);
+    ack?.({ studentId: socket.id });
+  });
+
+  socket.on('student:answer', ({ questionId, payload }) => {
+    const agg = aggregates.get(questionId);
+    if (!agg) return;
+    agg.total++;
+    if (typeof payload === 'number') agg.counts[payload]++;
+    else if (typeof payload === 'boolean') agg.tf[payload ? 'true' : 'false']++;
+    else if (typeof payload === 'string') agg.text.set(payload, (agg.text.get(payload) || 0) + 1);
+    io.to([...socket.rooms].filter(r => r.startsWith('room:'))).emit('stats:update', serializeAgg(questionId));
+  });
+});
+
+function serializeAgg(id: string) {
+  const a = aggregates.get(id);
+  return {
+    questionId: id,
+    total: a?.total || 0,
+    counts: a?.counts || [],
+    tfCounts: a?.tf || { true: 0, false: 0 },
+    textTop: a?.text ? [...a.text.entries()].sort((x, y) => y[1] - x[1]).slice(0, 50) : []
+  };
+}
+
+server.listen(5174, () => console.log('Server on http://localhost:5174'));

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "web",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "@mui/material": "^5.15.14",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "recharts": "^2.10.3",
+    "socket.io-client": "^4.7.5",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,0 +1,2 @@
+import { io } from 'socket.io-client';
+export const socket = io('/room', { path: '/socket.io', autoConnect: true });

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { createTheme, ThemeProvider, CssBaseline } from '@mui/material';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import Join from './pages/Join';
+import Student from './pages/Student';
+import Teacher from './pages/Teacher';
+import Screen from './pages/Screen';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#3949ab' }, // indigo
+    secondary: { main: '#00897b' } // teal
+  },
+  shape: { borderRadius: 16 },
+  typography: { fontSize: 16 }
+});
+
+const router = createBrowserRouter([
+  { path: '/', element: <Join/> },
+  { path: '/join', element: <Join/> },
+  { path: '/student/:code', element: <Student/> },
+  { path: '/teacher/:code', element: <Teacher/> },
+  { path: '/screen/:code', element: <Screen/> }
+]);
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <RouterProvider router={router} />
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/web/src/pages/Join.tsx
+++ b/web/src/pages/Join.tsx
@@ -1,0 +1,26 @@
+import { Container, TextField, Button, Paper, Stack, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+
+export default function Join(){
+  const nav = useNavigate();
+  const [code, setCode] = useState('');
+  const [name, setName] = useState('');
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Paper sx={{ p: 4 }}>
+        <Stack spacing={2}>
+          <Typography variant="h5">加入课堂互动</Typography>
+          <TextField label="房间码" value={code} onChange={e=>setCode(e.target.value.toUpperCase())} inputProps={{ maxLength: 6 }} />
+          <TextField label="昵称(可选)" value={name} onChange={e=>setName(e.target.value)} />
+          <Stack direction="row" spacing={2}>
+            <Button variant="contained" onClick={()=>nav(`/student/${code}?name=${encodeURIComponent(name)}`)}>我是学生</Button>
+            <Button variant="outlined" onClick={()=>nav(`/teacher/${code}`)}>我是老师</Button>
+            <Button onClick={()=>nav(`/screen/${code}`)}>大屏端</Button>
+          </Stack>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/web/src/pages/Screen.tsx
+++ b/web/src/pages/Screen.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { socket } from '../lib/ws';
+import { Container, Paper, Stack, Typography } from '@mui/material';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+export default function Screen(){
+  const { code } = useParams();
+  const [question, setQuestion] = useState<any>(null);
+  const [stats, setStats] = useState<any>({ counts: [] });
+
+  useEffect(()=>{
+    socket.emit('student:join', { code, nickname: 'SCREEN', anonymous: true });
+    socket.on('question:published', setQuestion);
+    socket.on('stats:update', setStats);
+    return ()=>{
+      socket.off('question:published', setQuestion);
+      socket.off('stats:update', setStats);
+    }
+  }, [code]);
+
+  const data = (question?.options||[]).map((o:string, i:number)=> ({ name: String.fromCharCode(65+i), value: stats.counts?.[i] || 0 }));
+
+  return (
+    <Container maxWidth="lg" sx={{ mt: 4 }}>
+      <Paper sx={{ p: 3 }}>
+        <Stack spacing={2}>
+          <Typography variant="overline">房间 {code}</Typography>
+          <Typography variant="h4">{question ? question.title : '等待教师发布题目…'}</Typography>
+          {question && question.type==='single' && (
+            <div style={{ width: '100%', height: 360 }}>
+              <ResponsiveContainer>
+                <BarChart data={data}>
+                  <XAxis dataKey="name" />
+                  <YAxis allowDecimals={false} />
+                  <Tooltip />
+                  <Bar dataKey="value" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+          {/* 判断/填空图表可按需求扩展 */}
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/web/src/pages/Student.tsx
+++ b/web/src/pages/Student.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { socket } from '../lib/ws';
+import { Box, Button, Container, Grid, Paper, Stack, Typography } from '@mui/material';
+
+export default function Student(){
+  const { code } = useParams();
+  const [sp] = useSearchParams();
+  const [question, setQuestion] = useState<any>(null);
+  const [submitted, setSubmitted] = useState<any>(null);
+
+  useEffect(()=>{
+    socket.emit('student:join', { code, nickname: sp.get('name') || '匿名', anonymous: !sp.get('name') });
+    socket.on('question:published', setQuestion);
+    return ()=>{
+      socket.off('question:published', setQuestion);
+    }
+  }, [code]);
+
+  function answer(payload: any){
+    if(!question) return;
+    socket.emit('student:answer', { questionId: question.id, payload });
+    setSubmitted(payload);
+  }
+
+  const optionButtons = useMemo(()=>{
+    if(!question) return null;
+    if(question.type === 'single'){
+      return (
+        <Grid container spacing={2}>
+          {question.options.map((opt:string, idx:number)=> (
+            <Grid item xs={6} key={idx}>
+              <Button fullWidth size="large" variant={submitted===idx? 'contained':'outlined'} sx={{ py: 4 }} onClick={()=>answer(idx)}>
+                <Stack>
+                  <Typography variant="h4">{String.fromCharCode(65+idx)}</Typography>
+                  <Typography>{opt}</Typography>
+                </Stack>
+              </Button>
+            </Grid>
+          ))}
+        </Grid>
+      );
+    }
+    if(question.type === 'tf'){
+      return (
+        <Grid container spacing={2}>
+          <Grid item xs={6}><Button fullWidth size="large" sx={{ py: 4 }} variant={submitted===true?'contained':'outlined'} onClick={()=>answer(true)}>对</Button></Grid>
+          <Grid item xs={6}><Button fullWidth size="large" sx={{ py: 4 }} variant={submitted===false?'contained':'outlined'} onClick={()=>answer(false)}>错</Button></Grid>
+        </Grid>
+      );
+    }
+    return <Typography>请在发布后输入文本答案（v1 省略）。</Typography>
+  }, [question, submitted]);
+
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Paper sx={{ p: 3 }}>
+        <Stack spacing={2}>
+          <Typography variant="overline">房间 {code}</Typography>
+          <Typography variant="h6">{question ? question.title : '等待教师发布题目…'}</Typography>
+          <Box>{optionButtons}</Box>
+          {submitted!==null && <Typography color="secondary">已提交</Typography>}
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/web/src/pages/Teacher.tsx
+++ b/web/src/pages/Teacher.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { socket } from '../lib/ws';
+import { Box, Button, Checkbox, Container, FormControlLabel, Grid, MenuItem, Paper, Stack, TextField, Typography } from '@mui/material';
+
+export default function Teacher(){
+  const { code } = useParams();
+  const [qType, setQType] = useState<'single'|'tf'|'text'>('single');
+  const [title, setTitle] = useState('');
+  const [options, setOptions] = useState(['A 选项','B 选项','C 选项','D 选项']);
+  const [timer, setTimer] = useState(30);
+  const [allowChange, setAllowChange] = useState(true);
+
+  useEffect(()=>{
+    socket.emit('student:join', { code, nickname: 'TEACHER', anonymous: true });
+  }, [code]);
+
+  async function publish(){
+    const id = Math.random().toString(36).slice(2);
+    const question = { id, code, type: qType, title, options: qType==='single'? options : undefined, timerSec: timer };
+    // Demo：直接通过 WS 发布（生产应走 REST 再 WS）
+    socket.emit('teacher:publish', { questionId: id }); // 协议留空，示意
+    socket.emit('question:published', question); // 本地演示
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Paper sx={{ p: 3 }}>
+        <Stack spacing={2}>
+          <Typography variant="overline">房间 {code}</Typography>
+          <Typography variant="h5">发布题目</Typography>
+          <TextField select label="题型" value={qType} onChange={e=>setQType(e.target.value as any)}>
+            <MenuItem value="single">单选</MenuItem>
+            <MenuItem value="tf">判断</MenuItem>
+            <MenuItem value="text">填空</MenuItem>
+          </TextField>
+          <TextField label="题干" value={title} onChange={e=>setTitle(e.target.value)} />
+          {qType==='single' && (
+            <Grid container spacing={2}>
+              {options.map((opt, i)=> (
+                <Grid item xs={6} key={i}>
+                  <TextField label={`选项 ${String.fromCharCode(65+i)}`} fullWidth value={opt}
+                    onChange={e=>{
+                      const arr = [...options]; arr[i] = e.target.value; setOptions(arr);
+                    }} />
+                </Grid>
+              ))}
+            </Grid>
+          )}
+          <Box>
+            <TextField label="计时(秒)" type="number" value={timer} onChange={e=>setTimer(parseInt(e.target.value||'0'))} sx={{ mr: 2 }} />
+            <FormControlLabel control={<Checkbox checked={allowChange} onChange={e=>setAllowChange(e.target.checked)} />} label="允许改答" />
+          </Box>
+          <Stack direction="row" spacing={2}>
+            <Button variant="contained" onClick={publish}>开始发布</Button>
+            <Button>结束作答</Button>
+            <Button variant="outlined">揭晓答案</Button>
+          </Stack>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add monorepo packages for server and web clients
- implement Express + Socket.IO backend with in-memory rooms and answer aggregation
- add React + Vite frontend with pages for join, student, teacher, and screen views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm -w server test` *(fails: Missing script "test")*
- `npm -w web test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68981aed49ec832191308c2cf91fea37